### PR TITLE
FIX: Display date in history

### DIFF
--- a/src/components/historypage/recent-runs-card.tsx
+++ b/src/components/historypage/recent-runs-card.tsx
@@ -89,11 +89,13 @@ export default function RecentRunsCard() {
 
 function RunCardItem({ run }: { run: TrainingSession }) {
   const roundedPaceTwoDecimals = run.achievedPace.toFixed(2);
+  const formattedDate = format(new Date(run.date + "T12:00:00Z"), "MMM d, yyyy");
+  
   return (
     <div className="flex flex-col sm:flex-row gap-4 p-4 border rounded-lg">
       <div className="sm:w-1/4">
         <div className="text-lg font-semibold">
-          {format(new Date(run.date), "MMM d, yyyy")}
+          {formattedDate}
         </div>
         <div className="text-muted-foreground">{run.trainingPlanId ?? "—"}</div>
       </div>


### PR DESCRIPTION
## Description
ISSUE: In history, the dates for the displayed runs were off by one day from the actual date retrieved from backend because of some timezone conversion.
FIX: Prevented timezone shift

## Related Issue/PR

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

> Make sure that you are making a PR in the right branch, 'dev-env' for development environment and 'main' for production environment.
